### PR TITLE
Add "parents" attribute to file

### DIFF
--- a/storage-api-drive-nongms/src/main/java/com/omh/android/storage/api/drive/nongms/data/GoogleStorageApiService.kt
+++ b/storage-api-drive-nongms/src/main/java/com/omh/android/storage/api/drive/nongms/data/GoogleStorageApiService.kt
@@ -1,6 +1,6 @@
 package com.omh.android.storage.api.drive.nongms.data
 
-import com.omh.android.storage.api.drive.nongms.data.source.body.CreateFileBody
+import com.omh.android.storage.api.drive.nongms.data.source.body.CreateFileRequestBody
 import com.omh.android.storage.api.drive.nongms.data.source.response.FileListRemoteResponse
 import com.omh.android.storage.api.drive.nongms.data.source.response.FileRemoteResponse
 import retrofit2.Call
@@ -18,7 +18,7 @@ internal interface GoogleStorageApiService {
         private const val QUERY_FIELDS = "fields"
 
         private const val Q_VALUE = "'root' in parents and trashed = false"
-        private const val QUERY_REQUESTED_FIELDS = "id,name,mimeType,modifiedTime"
+        private const val QUERY_REQUESTED_FIELDS = "id,name,mimeType,modifiedTime,parents"
         private const val FIELDS_VALUE = "files($QUERY_REQUESTED_FIELDS)"
     }
 
@@ -31,6 +31,6 @@ internal interface GoogleStorageApiService {
     @POST(FILES_PARTICLE)
     fun createFile(
         @Query(QUERY_FIELDS) query: String = QUERY_REQUESTED_FIELDS,
-        @Body body: CreateFileBody
+        @Body body: CreateFileRequestBody
     ): Call<FileRemoteResponse>
 }

--- a/storage-api-drive-nongms/src/main/java/com/omh/android/storage/api/drive/nongms/data/repository/NonGmsFileRepositoryImpl.kt
+++ b/storage-api-drive-nongms/src/main/java/com/omh/android/storage/api/drive/nongms/data/repository/NonGmsFileRepositoryImpl.kt
@@ -9,7 +9,8 @@ internal class NonGmsFileRepositoryImpl(
 
     override fun getRootFilesList() = dataSource.getRootFilesList()
 
-    override fun createFile(name: String, mimeType: String) = dataSource.createFile(name, mimeType)
+    override fun createFile(name: String, mimeType: String, parentId: String?) =
+        dataSource.createFile(name, mimeType, parentId)
 
     override fun open() = Unit
 

--- a/storage-api-drive-nongms/src/main/java/com/omh/android/storage/api/drive/nongms/data/source/NonGmsFileRemoteDataSourceImpl.kt
+++ b/storage-api-drive-nongms/src/main/java/com/omh/android/storage/api/drive/nongms/data/source/NonGmsFileRemoteDataSourceImpl.kt
@@ -3,7 +3,7 @@ package com.omh.android.storage.api.drive.nongms.data.source
 import com.omh.android.storage.api.data.source.OmhFileRemoteDataSource
 import com.omh.android.storage.api.domain.model.OmhFile
 import com.omh.android.storage.api.drive.nongms.data.GoogleRetrofitImpl
-import com.omh.android.storage.api.drive.nongms.data.source.body.CreateFileBody
+import com.omh.android.storage.api.drive.nongms.data.source.body.CreateFileRequestBody
 import com.omh.android.storage.api.drive.nongms.data.source.mapper.toFile
 import com.omh.android.storage.api.drive.nongms.data.source.mapper.toFileList
 
@@ -23,10 +23,16 @@ internal class NonGmsFileRemoteDataSourceImpl(private val retrofitImpl: GoogleRe
         }
     }
 
-    override fun createFile(name: String, mimeType: String): OmhFile? {
+    override fun createFile(name: String, mimeType: String, parentId: String?): OmhFile? {
+        val parents = if (parentId.isNullOrBlank()) {
+            emptyList()
+        } else {
+            listOf(parentId)
+        }
+
         val response = retrofitImpl
             .getGoogleStorageApiService()
-            .createFile(body = CreateFileBody(mimeType, name))
+            .createFile(body = CreateFileRequestBody(mimeType, name, parents))
             .execute()
 
         return if (response.isSuccessful) {

--- a/storage-api-drive-nongms/src/main/java/com/omh/android/storage/api/drive/nongms/data/source/body/CreateFileBody.kt
+++ b/storage-api-drive-nongms/src/main/java/com/omh/android/storage/api/drive/nongms/data/source/body/CreateFileBody.kt
@@ -1,6 +1,0 @@
-package com.omh.android.storage.api.drive.nongms.data.source.body
-
-data class CreateFileBody(
-    val mimeType: String,
-    val name: String
-)

--- a/storage-api-drive-nongms/src/main/java/com/omh/android/storage/api/drive/nongms/data/source/body/CreateFileRequestBody.kt
+++ b/storage-api-drive-nongms/src/main/java/com/omh/android/storage/api/drive/nongms/data/source/body/CreateFileRequestBody.kt
@@ -1,0 +1,7 @@
+package com.omh.android.storage.api.drive.nongms.data.source.body
+
+internal data class CreateFileRequestBody(
+    val mimeType: String,
+    val name: String,
+    val parents: List<String> = emptyList()
+)

--- a/storage-api-drive-nongms/src/main/java/com/omh/android/storage/api/drive/nongms/data/source/mapper/DataMappers.kt
+++ b/storage-api-drive-nongms/src/main/java/com/omh/android/storage/api/drive/nongms/data/source/mapper/DataMappers.kt
@@ -10,11 +10,18 @@ internal fun FileRemoteResponse.toFile(): OmhFile? {
         return null
     }
 
+    val parentId = if (parents.isNullOrEmpty()) {
+        ""
+    } else {
+        parents[0]
+    }
+
     return OmhFile(
         mimeType,
         id,
         name,
-        modifiedTime
+        modifiedTime,
+        parentId
     )
 }
 

--- a/storage-api-drive-nongms/src/main/java/com/omh/android/storage/api/drive/nongms/data/source/response/FileRemoteResponse.kt
+++ b/storage-api-drive-nongms/src/main/java/com/omh/android/storage/api/drive/nongms/data/source/response/FileRemoteResponse.kt
@@ -8,5 +8,6 @@ internal data class FileRemoteResponse(
     @JsonProperty("mimeType")val mimeType: String?,
     @JsonProperty("id")val id: String?,
     @JsonProperty("name")val name: String?,
-    @JsonProperty("modifiedTime")val modifiedTime: String?
+    @JsonProperty("modifiedTime")val modifiedTime: String?,
+    @JsonProperty("parents")val parents: List<String>?
 )

--- a/storage-api/src/main/java/com/omh/android/storage/api/data/source/OmhFileRemoteDataSource.kt
+++ b/storage-api/src/main/java/com/omh/android/storage/api/data/source/OmhFileRemoteDataSource.kt
@@ -6,5 +6,5 @@ interface OmhFileRemoteDataSource {
 
     fun getRootFilesList(): List<OmhFile>
 
-    fun createFile(name: String, mimeType: String): OmhFile?
+    fun createFile(name: String, mimeType: String, parentId: String?): OmhFile?
 }

--- a/storage-api/src/main/java/com/omh/android/storage/api/domain/model/OmhFile.kt
+++ b/storage-api/src/main/java/com/omh/android/storage/api/domain/model/OmhFile.kt
@@ -6,7 +6,8 @@ data class OmhFile(
     val mimeType: String,
     val id: String,
     val name: String,
-    val modifiedTime: String
+    val modifiedTime: String,
+    val parentId: String
 ) {
     val fileType by lazy { FileTypeMapper.getFileTypeWithMime(mimeType) }
 

--- a/storage-api/src/main/java/com/omh/android/storage/api/domain/repository/FileRepository.kt
+++ b/storage-api/src/main/java/com/omh/android/storage/api/domain/repository/FileRepository.kt
@@ -6,7 +6,7 @@ interface FileRepository {
 
     fun getRootFilesList(): List<OmhFile>
 
-    fun createFile(name: String, mimeType: String): OmhFile?
+    fun createFile(name: String, mimeType: String, parentId: String?): OmhFile?
 
     fun open()
 

--- a/storage-api/src/main/java/com/omh/android/storage/api/domain/usecase/CreateFileUseCase.kt
+++ b/storage-api/src/main/java/com/omh/android/storage/api/domain/usecase/CreateFileUseCase.kt
@@ -11,10 +11,10 @@ class CreateFileUseCase(
 ) : OmhSuspendUseCase<CreateFileUseCaseParams, CreateFileUseCaseResult>(dispatcher) {
 
     override suspend fun execute(parameters: CreateFileUseCaseParams) = CreateFileUseCaseResult(
-        repository.createFile(parameters.name, parameters.mimeType)
+        repository.createFile(parameters.name, parameters.mimeType, parameters.parentId)
     )
 }
 
-data class CreateFileUseCaseParams(val name: String, val mimeType: String)
+data class CreateFileUseCaseParams(val name: String, val mimeType: String, val parentId: String?)
 
 data class CreateFileUseCaseResult(val file: OmhFile?)


### PR DESCRIPTION
Added "parents" attribute to OmhFile and to FileRemoteResponse. This will be important for create and locate files.
The "parents" attribute is the id of the folder which contains it (or where will be created)

This PR depends on #17, and can see easy diff [clicking here](https://github.com/openmobilehub/omh-storage/compare/state/createFileNonGMS...state/addParentsAttributToFile).