### PR TITLE
Remove use case injection

### DIFF
--- a/storage-api/src/main/java/com/omh/android/storage/api/OmhStorageClient.kt
+++ b/storage-api/src/main/java/com/omh/android/storage/api/OmhStorageClient.kt
@@ -2,6 +2,7 @@ package com.omh.android.storage.api
 
 import com.omh.android.auth.api.OmhAuthClient
 import com.omh.android.storage.api.domain.repository.FileRepository
+import com.omh.android.storage.api.domain.usecase.GetFilesListWithParentIdUseCase
 
 abstract class OmhStorageClient protected constructor(
     protected val authClient: OmhAuthClient
@@ -12,5 +13,13 @@ abstract class OmhStorageClient protected constructor(
         fun build(authClient: OmhAuthClient): OmhStorageClient
     }
 
-    abstract fun getRepository(): FileRepository
+    protected abstract fun getRepository(): FileRepository
+
+    /*
+     * TODO: This must return an asynchronous task that can be executed with any library
+     *  capable to manage this. In the future, this task must be implemented from auth
+     *  and will not return an use case
+     */
+    @SuppressWarnings("ForbiddenComment")
+    fun listFiles() = GetFilesListWithParentIdUseCase(getRepository())
 }

--- a/storage-sample/src/main/java/com/omh/android/storage/sample/di/SingletonModule.kt
+++ b/storage-sample/src/main/java/com/omh/android/storage/sample/di/SingletonModule.kt
@@ -5,7 +5,6 @@ import com.omh.android.auth.api.OmhAuthClient
 import com.omh.android.auth.api.OmhAuthProvider
 import com.omh.android.storage.api.OmhStorageClient
 import com.omh.android.storage.api.OmhStorageProvider
-import com.omh.android.storage.api.domain.usecase.GetFilesListWithParentIdUseCase
 import com.omh.android.storage.sample.BuildConfig
 import dagger.Module
 import dagger.Provides
@@ -39,8 +38,4 @@ class SingletonModule {
     fun providesOmhStorageClient(omhAuthClient: OmhAuthClient): OmhStorageClient {
         return OmhStorageProvider.provideStorageClient(omhAuthClient)
     }
-
-    @Provides
-    fun providesGetFilesListWithParentIdUseCase(omhStorageClient: OmhStorageClient) =
-        GetFilesListWithParentIdUseCase(omhStorageClient.getRepository())
 }

--- a/storage-sample/src/main/java/com/omh/android/storage/sample/presentation/BaseViewModel.kt
+++ b/storage-sample/src/main/java/com/omh/android/storage/sample/presentation/BaseViewModel.kt
@@ -7,7 +7,6 @@ import androidx.lifecycle.viewModelScope
 import com.omh.android.storage.sample.util.LOG_MESSAGE_EVENT
 import com.omh.android.storage.sample.util.TAG_VIEW_UPDATE
 import com.omh.android.storage.sample.util.launchSafe
-import kotlinx.coroutines.CoroutineDispatcher
 
 abstract class BaseViewModel<State : ViewState, Event : ViewEvent> : ViewModel() {
 

--- a/storage-sample/src/main/java/com/omh/android/storage/sample/presentation/file_viewer/FileViewerViewModel.kt
+++ b/storage-sample/src/main/java/com/omh/android/storage/sample/presentation/file_viewer/FileViewerViewModel.kt
@@ -1,17 +1,15 @@
 package com.omh.android.storage.sample.presentation.file_viewer
 
-import com.omh.android.storage.api.domain.usecase.GetFilesListWithParentIdUseCase
+import com.omh.android.storage.api.OmhStorageClient
 import com.omh.android.storage.api.domain.usecase.GetFilesListWithParentIdUseCaseParams
 import com.omh.android.storage.api.domain.usecase.OmhResult
-import com.omh.android.storage.sample.di.DefaultDispatcher
 import com.omh.android.storage.sample.presentation.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.CoroutineDispatcher
 import javax.inject.Inject
 
 @HiltViewModel
 class FileViewerViewModel @Inject constructor(
-    private val getFilesListWithParentIdUseCase: GetFilesListWithParentIdUseCase,
+    private val omhStorageClient: OmhStorageClient
 ) : BaseViewModel<FileViewerViewState, FileViewerViewEvent>() {
 
     var isGridLayoutManager = true
@@ -33,9 +31,10 @@ class FileViewerViewModel @Inject constructor(
     private suspend fun refreshFileListEvent(parentId: String = "root") {
         setState(FileViewerViewState.Loading)
 
+        val listFiles = omhStorageClient.listFiles()
+
         when (
-            val result =
-                getFilesListWithParentIdUseCase(GetFilesListWithParentIdUseCaseParams(parentId))
+            val result = listFiles(GetFilesListWithParentIdUseCaseParams(parentId))
         ) {
             is OmhResult.OmhSuccess -> {
                 setState(FileViewerViewState.Content(result.data.files))


### PR DESCRIPTION
The purpose of this is let a template for don't provide use cases on sample app. Instead, get use cases through repository.

In the future, will return a task that can be executed from client using any desired library.

This PR depends on #24, and can see easy diff [clicking here](https://github.com/openmobilehub/omh-storage/compare/state/swapGridListLayoutManager...state/removeUseCaseInjection).