### PR TITLE
Sample app - bugfix - Download Crash With Invalid Filename

### DIFF
--- a/storage-sample/src/main/java/com/omh/android/storage/sample/presentation/file_viewer/FileViewerFragment.kt
+++ b/storage-sample/src/main/java/com/omh/android/storage/sample/presentation/file_viewer/FileViewerFragment.kt
@@ -162,6 +162,22 @@ class FileViewerFragment :
         FileViewerViewState.CheckPermissions -> requestPermissions()
         FileViewerViewState.SignOut -> buildSignOutState()
         is FileViewerViewState.ShowUpdateFilePicker -> launchUpdateFilePicker()
+        FileViewerViewState.ShowDownloadExceptionDialog -> showDownloadExceptionDialog()
+    }
+
+    private fun showDownloadExceptionDialog() {
+        context?.let { context ->
+            val downloadExceptionDialogBuilder = AlertDialog.Builder(context)
+                .setTitle(getString(R.string.text_download_error_title))
+                .setMessage(getString(R.string.text_download_error_message))
+                .setPositiveButton(getString(R.string.text_accept)) { dialog, _ -> dialog.dismiss() }
+
+            val downloadExceptionDialog = downloadExceptionDialogBuilder.create().apply {
+                setCancelable(false)
+            }
+
+            downloadExceptionDialog.show()
+        }
     }
 
     private fun buildInitialState() {

--- a/storage-sample/src/main/java/com/omh/android/storage/sample/presentation/file_viewer/FileViewerViewModel.kt
+++ b/storage-sample/src/main/java/com/omh/android/storage/sample/presentation/file_viewer/FileViewerViewModel.kt
@@ -28,6 +28,7 @@ import com.omh.android.storage.sample.domain.model.FileType
 import com.omh.android.storage.sample.presentation.BaseViewModel
 import com.omh.android.storage.sample.util.getNameWithExtension
 import com.omh.android.storage.sample.util.isDownloadable
+import com.omh.android.storage.sample.util.normalizeFileName
 import com.omh.android.storage.sample.util.normalizedMimeType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.io.File
@@ -150,10 +151,18 @@ class FileViewerViewModel @Inject constructor(
 
             val cancellable = omhStorageClient.downloadFile(file.id, mimeTypeToSave)
                 .addOnSuccess { data ->
-                    val fileToSave = file.copy(mimeType = mimeTypeToSave)
+                    val fileToSave = file.copy(
+                        name = file.normalizeFileName(),
+                        mimeType = mimeTypeToSave
+                    )
 
-                    handleDownloadSuccess(data, fileToSave)
-                    toastMessage.postValue("${file.name} was successfully downloaded")
+                    try {
+                        handleDownloadSuccess(data, fileToSave)
+                        toastMessage.postValue("${file.name} was successfully downloaded")
+                    } catch (exception: Exception) {
+                        exception.printStackTrace()
+                        setState(FileViewerViewState.ShowDownloadExceptionDialog)
+                    }
                     refreshFileListEvent()
                 }
                 .addOnFailure {

--- a/storage-sample/src/main/java/com/omh/android/storage/sample/presentation/file_viewer/FileViewerViewState.kt
+++ b/storage-sample/src/main/java/com/omh/android/storage/sample/presentation/file_viewer/FileViewerViewState.kt
@@ -60,4 +60,9 @@ sealed class FileViewerViewState : ViewState {
 
         override fun getName() = "FileViewerViewState.FilePicker"
     }
+
+    object ShowDownloadExceptionDialog : FileViewerViewState() {
+
+        override fun getName() = "FileViewerViewState.ShowDownloadExceptionDialog"
+    }
 }

--- a/storage-sample/src/main/java/com/omh/android/storage/sample/util/Extensions.kt
+++ b/storage-sample/src/main/java/com/omh/android/storage/sample/util/Extensions.kt
@@ -66,6 +66,18 @@ fun OmhFile.normalizedMimeType(): String = when (fileType) {
     else -> this.mimeType
 }
 
+fun OmhFile.normalizeFileName(): String {
+    val invalidChars = Regex("[\\\\/:*?\"'<>|]")
+
+    var downloadName = name.replace(invalidChars, " ")
+
+    if (downloadName.length >= 255) {
+        downloadName = downloadName.substring(0..254)
+    }
+
+    return downloadName
+}
+
 fun OmhFile.getNameWithExtension(): String = if (isFileNameWithExtension(name)) {
     name
 } else {

--- a/storage-sample/src/main/res/values/strings.xml
+++ b/storage-sample/src/main/res/values/strings.xml
@@ -8,6 +8,9 @@
     <string name="text_name">Name</string>
     <string name="text_swap_grid_linear">Swap Grid/Linear</string>
     <string name="text_create_file_title">Create File</string>
+    <string name="text_download_error_title">Download Error</string>
+    <string name="text_download_error_message">There was an error during download process.\n\nPlease make sure the name of the file don\'t have special characters (for example ?, *, ", [, ], \').\n\nPlease go to your drive account and change the name of the file.</string>
+    <string name="text_accept">Accept</string>
     <string name="text_file_name_label">File Name:</string>
     <string name="text_file_type_label">File Type:</string>
     <string name="text_upload_file_title">Upload File</string>


### PR DESCRIPTION
Fix for catch exception when a remote file have invalid name

This PR is related to issue #99 